### PR TITLE
swap order of List fields for 64 + 32-bit version

### DIFF
--- a/benchmark32_test.go
+++ b/benchmark32_test.go
@@ -1,0 +1,352 @@
+package hashmap
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sync/syncmap"
+)
+
+//const benchmarkItemCount = 1 << 10 // 1024
+
+func setupHashMap32(b *testing.B) *HashMap32 {
+	m := &HashMap32{}
+	for i := uint32(0); i < benchmarkItemCount; i++ {
+		j := uintptr(i)
+		m.Set(i, unsafe.Pointer(&j))
+	}
+
+	b.ResetTimer()
+	return m
+}
+
+func setupHashMapString32(b *testing.B) *HashMap32 {
+	m := &HashMap32{}
+	for i := 0; i < benchmarkItemCount; i++ {
+		s := strconv.Itoa(i)
+		m.Set(s, unsafe.Pointer(&s))
+	}
+
+	b.ResetTimer()
+	return m
+}
+
+func writeHashMap32(m *HashMap32, i uint32) {
+	j := uintptr(i)
+	m.Set(i, unsafe.Pointer(&j))
+}
+
+func setupHashMapHashedKey32(b *testing.B) *HashMap32 {
+	m := &HashMap32{}
+	log := log2_32(uint32(benchmarkItemCount))
+	for i := uint32(0); i < benchmarkItemCount; i++ {
+		hash := i << (32 - log)
+		j := uintptr(i)
+		m.SetHashedKey(hash, unsafe.Pointer(&j))
+	}
+
+	b.ResetTimer()
+	return m
+}
+
+func setupGoMap32(b *testing.B) map[uint32]uint32 {
+	m := make(map[uint32]uint32)
+	for i := uint32(0); i < benchmarkItemCount; i++ {
+		m[i] = i
+	}
+
+	b.ResetTimer()
+	return m
+}
+
+func writeGoMap32(m map[uint32]uint32, i uint32, mtx *sync.RWMutex) {
+	mtx.Lock()
+	m[i] = i
+	mtx.Unlock()
+}
+
+func setupGoSyncMap32(b *testing.B) *syncmap.Map {
+	m := &syncmap.Map{}
+	for i := uint32(0); i < benchmarkItemCount; i++ {
+		m.Store(i, i)
+	}
+
+	b.ResetTimer()
+	return m
+}
+
+func writeGoSyncMap32(m *syncmap.Map, i uint32) {
+	m.Store(i, i)
+}
+
+func setupGoMapString32(b *testing.B) map[string]string {
+	m := make(map[string]string)
+	for i := 0; i < benchmarkItemCount; i++ {
+		s := strconv.Itoa(i)
+		m[s] = s
+	}
+	b.ResetTimer()
+	return m
+}
+
+func BenchmarkReadHashMapUint32(b *testing.B) {
+	m := setupHashMap32(b)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				j, _ := m.GetUintKey(i)
+				if *(*uint32)(j) != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadHashMapWithWritesUint32(b *testing.B) {
+	m := setupHashMap32(b)
+
+	go func(bn int) {
+		for n := 0; n < bn; n++ {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				writeHashMap32(m, i)
+			}
+		}
+	}(b.N)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				j, _ := m.GetUintKey(i)
+				if *(*uint32)(j) != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadHashMapString32(b *testing.B) {
+	m := setupHashMapString32(b)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := 0; i < benchmarkItemCount; i++ {
+				s := strconv.Itoa(i)
+				sVal, _ := m.GetStringKey(s)
+				if *(*string)(sVal) != s {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadHashMapInterface32(b *testing.B) {
+	m := setupHashMap32(b)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				j, _ := m.Get(i)
+				if *(*uint32)(j) != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadHashMapHashedKey32(b *testing.B) {
+	m := setupHashMapHashedKey32(b)
+	log := log2_32(uint32(benchmarkItemCount))
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				hash := i << (32 - log)
+				j, _ := m.GetHashedKey(hash)
+				if *(*uint32)(j) != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoMapUintUnsafe32(b *testing.B) {
+	m := setupGoMap32(b)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				j, _ := m[i]
+				if j != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoMapUintMutex32(b *testing.B) {
+	m := setupGoMap32(b)
+	l := &sync.RWMutex{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				l.RLock()
+				j, _ := m[i]
+				l.RUnlock()
+				if j != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoMapWithWritesUintMutex32(b *testing.B) {
+	m := setupGoMap32(b)
+	l := &sync.RWMutex{}
+
+	go func(bn int) {
+		for n := 0; n < bn; n++ {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				writeGoMap32(m, i, l)
+			}
+		}
+	}(b.N)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				l.RLock()
+				j, _ := m[i]
+				l.RUnlock()
+				if j != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoSyncMapUint32(b *testing.B) {
+	m := setupGoSyncMap32(b)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				j, _ := m.Load(i)
+				if j != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoSyncMapWithWritesUint32(b *testing.B) {
+	m := setupGoSyncMap32(b)
+
+	go func(bn int) {
+		for n := 0; n < bn; n++ {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				writeGoSyncMap32(m, i)
+			}
+		}
+	}(b.N)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := uint32(0); i < benchmarkItemCount; i++ {
+				j, _ := m.Load(i)
+				if j != i {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoMapStringUnsafe32(b *testing.B) {
+	m := setupGoMapString32(b)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := 0; i < benchmarkItemCount; i++ {
+				s := strconv.Itoa(i)
+				sVal, _ := m[s]
+				if s != sVal {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadGoMapStringMutex32(b *testing.B) {
+	m := setupGoMapString32(b)
+	l := &sync.RWMutex{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := 0; i < benchmarkItemCount; i++ {
+				s := strconv.Itoa(i)
+				l.RLock()
+				sVal, _ := m[s]
+				l.RUnlock()
+				if s != sVal {
+					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkWriteHashMapUint32(b *testing.B) {
+	m := &HashMap32{}
+
+	for n := 0; n < b.N; n++ {
+		for i := uint32(0); i < benchmarkItemCount; i++ {
+			j := uintptr(i)
+			m.Set(i, unsafe.Pointer(&j))
+		}
+	}
+}
+
+func BenchmarkWriteHashMapHashedKey32(b *testing.B) {
+	m := &HashMap32{}
+	log := log2_32(uint32(benchmarkItemCount))
+
+	for n := 0; n < b.N; n++ {
+		for i := uint32(0); i < benchmarkItemCount; i++ {
+			hash := i << (64 - log)
+			j := uintptr(i)
+			m.SetHashedKey(hash, unsafe.Pointer(&j))
+		}
+	}
+}
+
+func BenchmarkWriteGoMapMutexUint32(b *testing.B) {
+	m := make(map[uint32]uint32)
+	l := &sync.RWMutex{}
+
+	for n := 0; n < b.N; n++ {
+		for i := uint32(0); i < benchmarkItemCount; i++ {
+			l.Lock()
+			m[i] = i
+			l.Unlock()
+		}
+	}
+}
+
+func BenchmarkWriteGoSyncMapUint32(b *testing.B) {
+	m := &syncmap.Map{}
+
+	for n := 0; n < b.N; n++ {
+		for i := uint32(0); i < benchmarkItemCount; i++ {
+			m.Store(i, i)
+		}
+	}
+}

--- a/hashmap.go
+++ b/hashmap.go
@@ -18,9 +18,9 @@ const MaxFillRate = 50
 type (
 	hashMapData struct {
 		keyRightShifts uint64         // 64 - log2 of array size, to be used as index in the data array
+		count          uint64         // count of filled elements in the slice
 		data           unsafe.Pointer // pointer to slice data array
 		slice          []*ListElement // storage for the slice for the garbage collector to not clean it up
-		count          uint64         // count of filled elements in the slice
 	}
 
 	// HashMap implements a read optimized hash map.

--- a/hashmap32.go
+++ b/hashmap32.go
@@ -1,0 +1,393 @@
+package hashmap
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+// DefaultSize is the default size for a zero allocated map
+const DefaultSize32 = 8
+
+// MaxFillRate is the maximum fill rate for the slice before a resize  will happen.
+const MaxFillRate32 = 50
+
+type (
+	hashMapData32 struct {
+		keyRightShifts uint32         // 32 now --> 64 - log2 of array size, to be used as index in the data array
+		count          uint32         // count of filled elements in the slice
+		data           unsafe.Pointer // pointer to slice data array
+		slice          []*ListElement32 // storage for the slice for the garbage collector to not clean it up
+	}
+
+	// HashMap32 implements a read optimized hash map.
+	HashMap32 struct {
+		mapDataPtr unsafe.Pointer // pointer to a map instance that gets replaced if the map resizes
+		linkedList unsafe.Pointer // key sorted linked list of elements
+		sync.Mutex                // mutex that is only used for resize operations
+	}
+
+	// KeyValue represents a key/value that is returned by the iterator.
+
+	// KeyValue struct {
+	// 	Key   interface{}
+	// 	Value unsafe.Pointer
+	// }
+)
+
+// New returns a new HashMap32 instance with a specific initialization size.
+func New32(size uint32) *HashMap32 {
+	m := &HashMap32{}
+	m.allocate(size)
+	return m
+}
+
+// Len returns the number of elements within the map.
+func (m *HashMap32) Len() uint32 {
+	list := m.list()
+	if list == nil {
+		return 0
+	}
+	return list.Len()
+}
+
+func (m *HashMap32) mapData() *hashMapData32 {
+	return (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+}
+
+func (m *HashMap32) list() *List32 {
+	return (*List32)(atomic.LoadPointer(&m.linkedList))
+}
+
+func (m *HashMap32) allocate(newSize uint32) {
+	m.Lock()
+	defer m.Unlock()
+
+	mapData := m.mapData()
+	if mapData != nil { // check that no other allocation happened
+		return
+	}
+
+	list := NewList32()
+	atomic.StorePointer(&m.linkedList, unsafe.Pointer(list))
+	m.grow(newSize)
+}
+
+// Fillrate returns the fill rate of the map as an percentage integer.
+func (m *HashMap32) Fillrate() uint32 {
+	mapData := m.mapData()
+	count := atomic.LoadUint32(&mapData.count)
+	sliceLen := uint32(len(mapData.slice))
+	return (count * 100) / sliceLen
+}
+
+func (m *HashMap32) getSliceItemForKey(hashedKey uint32) (mapData *hashMapData32, item *ListElement32) {
+	mapData = m.mapData()
+	if mapData == nil {
+		return nil, nil
+	}
+	index := hashedKey >> mapData.keyRightShifts
+	sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+	item = (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer))
+	return mapData, item
+}
+
+// Del deletes the hashed key from the map.
+func (m *HashMap32) Del(key interface{}) {
+	list := m.list()
+	if list == nil {
+		return
+	}
+
+	hashedKey := getKeyHash32(key)
+	for _, entry := m.getSliceItemForKey(hashedKey); entry != nil; entry = entry.Next() {
+		if entry.keyHash == hashedKey && entry.key == key {
+			list.Delete(entry)
+			return
+		}
+
+		if entry.keyHash > hashedKey {
+			return
+		}
+	}
+}
+
+// DelHashedKey deletes the hashed key from the map.
+func (m *HashMap32) DelHashedKey(hashedKey uint32) {
+	list := m.list()
+	if list == nil {
+		return
+	}
+
+	for _, entry := m.getSliceItemForKey(hashedKey); entry != nil; entry = entry.Next() {
+		if entry.keyHash == hashedKey {
+			list.Delete(entry)
+			return
+		}
+
+		if entry.keyHash > hashedKey {
+			return
+		}
+	}
+}
+
+// Insert sets the value under the specified key to the map if it does not exist yet.
+// If a resizing operation is happening concurrently while calling Set, the item might show up in the map only after the resize operation is finished.
+// Returns true if the item was inserted or false if it existed.
+func (m *HashMap32) Insert(key interface{}, value unsafe.Pointer) bool {
+	hashedKey := getKeyHash32(key)
+
+	newEntry := &ListElement32{
+		key:     key,
+		keyHash: hashedKey,
+		value:   value,
+	}
+
+	return m.insertListElement(newEntry, false)
+}
+
+// Set sets the value under the specified key to the map. An existing item for this key will be overwritten.
+// If a resizing operation is happening concurrently while calling Set, the item might show up in the map only after the resize operation is finished.
+func (m *HashMap32) Set(key interface{}, value unsafe.Pointer) {
+	hashedKey := getKeyHash32(key)
+
+	newEntry := &ListElement32{
+		key:     key,
+		keyHash: hashedKey,
+		value:   value,
+	}
+
+	m.insertListElement(newEntry, true)
+}
+
+// SetHashedKey sets the value under the specified hash key to the map. An existing item for this key will be overwritten.
+// You can use this function if your keys are already hashes and you want to avoid another hashing of the key.
+// Do not use non hashes as keys for this function, the performance would decrease!
+// If a resizing operation is happening concurrently while calling Set, the item might show up in the map only after the resize operation is finished.
+func (m *HashMap32) SetHashedKey(hashedKey uint32, value unsafe.Pointer) {
+	newEntry := &ListElement32{
+		key:     hashedKey,
+		keyHash: hashedKey,
+		value:   value,
+	}
+
+	m.insertListElement(newEntry, true)
+}
+
+func (m *HashMap32) insertListElement(newEntry *ListElement32, update bool) bool {
+	for {
+		mapData, sliceItem := m.getSliceItemForKey(newEntry.keyHash)
+		if mapData == nil {
+			m.allocate(DefaultSize32)
+			continue // read mapdata and slice item again
+		}
+		list := m.list()
+
+		if update {
+			if !list.AddOrUpdate(newEntry, sliceItem) {
+				continue // a concurrent add did interfere, try again
+			}
+		} else {
+			existed, inserted := list.Add(newEntry, sliceItem)
+			if existed {
+				return false
+			}
+			if !inserted {
+				continue
+			}
+		}
+
+		newSliceCount := mapData.addItemToIndex(newEntry)
+		if newSliceCount != 0 {
+			sliceLen := uint32(len(mapData.slice))
+			fillRate := (newSliceCount * 100) / sliceLen
+
+			if fillRate > MaxFillRate32 { // check if the slice needs to be resized
+				m.Lock()
+				currentMapData := m.mapData()
+				if mapData == currentMapData { // double check that no other resize happened
+					m.grow(0)
+				}
+				m.Unlock()
+			}
+		}
+		return true
+	}
+}
+
+// CasHashedKey performs a compare and swap operation sets the value under the specified hash key to the map. An existing item for this key will be overwritten.
+func (m *HashMap32) CasHashedKey(hashedKey uint32, from, to unsafe.Pointer) bool {
+	newEntry := &ListElement32{
+		key:     hashedKey,
+		keyHash: hashedKey,
+		value:   to,
+	}
+
+	for {
+		mapData, sliceItem := m.getSliceItemForKey(hashedKey)
+		if mapData == nil {
+			return false
+		}
+		list := m.list()
+		if list == nil {
+			return false
+		}
+		if !list.Cas(newEntry, from, sliceItem) {
+			return false
+		}
+
+		newSliceCount := mapData.addItemToIndex(newEntry)
+		if newSliceCount != 0 {
+			sliceLen := uint32(len(mapData.slice))
+			fillRate := (newSliceCount * 100) / sliceLen
+
+			if fillRate > MaxFillRate32 { // check if the slice needs to be resized
+				m.Lock()
+				currentMapData := m.mapData()
+				if mapData == currentMapData { // double check that no other resize happened
+					m.grow(0)
+				}
+				m.Unlock()
+			}
+		}
+		return true
+	}
+}
+
+// Cas performs a compare and swap operation sets the value under the specified hash key to the map. An existing item for this key will be overwritten.
+func (m *HashMap32) Cas(key interface{}, from, to unsafe.Pointer) bool {
+	hashedKey := getKeyHash32(key)
+	return m.CasHashedKey(hashedKey, from, to)
+}
+
+// adds an item to the index if needed and returns the new item counter if it changed, otherwise 0
+func (mapData *hashMapData32) addItemToIndex(item *ListElement32) uint32 {
+	index := item.keyHash >> mapData.keyRightShifts
+	sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+
+	for { // loop until the smallest key hash is in the index
+		sliceItem := (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer)) // get the current item in the index
+		if sliceItem == nil {                                                  // no item yet at this index
+			if atomic.CompareAndSwapPointer(sliceDataIndexPointer, nil, unsafe.Pointer(item)) {
+				return atomic.AddUint32(&mapData.count, 1)
+			}
+			continue // a new item was inserted concurrently, retry
+		}
+
+		if item.keyHash < sliceItem.keyHash {
+			// the new item is the smallest for this index?
+			if !atomic.CompareAndSwapPointer(sliceDataIndexPointer, unsafe.Pointer(sliceItem), unsafe.Pointer(item)) {
+				continue // a new item was inserted concurrently, retry
+			}
+		}
+		return 0
+	}
+}
+
+// Grow resizes the hashmap to a new size, gets rounded up to next power of 2.
+// To double the size of the hashmap use newSize 0.
+func (m *HashMap32) Grow(newSize uint32) {
+	m.Lock()
+	m.grow(newSize)
+	m.Unlock()
+}
+
+func (m *HashMap32) grow(newSize uint32) {
+	mapData := m.mapData()
+	if newSize == 0 {
+		newSize = uint32(len(mapData.slice)) << 1
+	} else {
+		newSize = roundUpPower2_32(newSize)
+	}
+
+	newSlice := make([]*ListElement32, newSize)
+	header := (*reflect.SliceHeader)(unsafe.Pointer(&newSlice))
+
+	newMapData := &hashMapData32{
+		keyRightShifts: 32 - log2_32(newSize),
+		data:           unsafe.Pointer(header.Data), // use address of slice data storage
+		slice:          newSlice,
+	}
+
+	m.fillIndexItems(newMapData) // initialize new index slice with longer keys
+
+	atomic.StorePointer(&m.mapDataPtr, unsafe.Pointer(newMapData))
+
+	m.fillIndexItems(newMapData) // make sure that the new index is up to date with the current state of the linked list
+}
+
+func (m *HashMap32) fillIndexItems(mapData *hashMapData32) {
+	list := m.list()
+	if list == nil {
+		return
+	}
+	first := list.First()
+	item := first
+	lastIndex := uint32(0)
+
+	for item != nil {
+		index := item.keyHash >> mapData.keyRightShifts
+		if item == first || index != lastIndex { // store item with smallest hash key for every index
+			if !item.Deleted() {
+				mapData.addItemToIndex(item)
+				lastIndex = index
+			}
+		}
+		item = item.Next()
+	}
+}
+
+// String returns the map as a string, only hashed keys are printed.
+func (m *HashMap32) String() string {
+	list := m.list()
+	if list == nil {
+		return "[]"
+	}
+
+	buffer := bytes.NewBufferString("")
+	buffer.WriteRune('[')
+
+	first := list.First()
+	item := first
+
+	for item != nil {
+		if !item.Deleted() {
+			if item != first {
+				buffer.WriteRune(',')
+			}
+			fmt.Fprint(buffer, item.keyHash)
+		}
+
+		item = item.Next()
+	}
+	buffer.WriteRune(']')
+	return buffer.String()
+}
+
+// Iter returns an iterator which could be used in a for range loop.
+// The order of the items is sorted by hash keys.
+func (m *HashMap32) Iter() <-chan KeyValue {
+	ch := make(chan KeyValue) // do not use a size here since items can get added during iteration
+
+	go func() {
+		list := m.list()
+		if list == nil {
+			close(ch)
+			return
+		}
+		item := list.First()
+		for item != nil {
+			value, ok := item.Value()
+			if ok {
+				ch <- KeyValue{item.key, value}
+			}
+			item = item.Next()
+		}
+		close(ch)
+	}()
+
+	return ch
+}

--- a/hashmap32_get.go
+++ b/hashmap32_get.go
@@ -1,0 +1,226 @@
+package hashmap
+
+import (
+	"reflect"
+	"sync/atomic"
+	"unsafe"
+
+//	"github.com/dchest/siphash"
+)
+
+// Get retrieves an element from the map under given hash key.
+// Using interface{} adds a performance penalty.
+// Please consider using GetUintKey or GetStringKey instead.
+func (m *HashMap32) Get(key interface{}) (value unsafe.Pointer, ok bool) {
+	hashedKey := getKeyHash32(key)
+
+	// inline HashMap32.getSliceItemForKey()
+	mapData := (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+	if mapData == nil {
+		return nil, false
+	}
+	index := hashedKey >> mapData.keyRightShifts
+	sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+	entry := (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer))
+
+	for entry != nil {
+		if entry.keyHash == hashedKey && entry.key == key {
+			// inline ListElement32.Value()
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			value = atomic.LoadPointer(&entry.value)
+			// read again to make sure that the item has not been deleted between the
+			// deleted check and reading of the value
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			return value, true
+		}
+
+		if entry.keyHash > hashedKey {
+			return nil, false
+		}
+
+		entry = (*ListElement32)(atomic.LoadPointer(&entry.nextElement)) // inline ListElement32.Next()
+	}
+	return nil, false
+}
+
+// GetUintKey retrieves an element from the map under given integer key.
+func (m *HashMap32) GetUintKey(key uint32) (value unsafe.Pointer, ok bool) {
+	mapData := (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+	if mapData == nil {
+		return nil, false
+	}
+
+	bh := reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(&key)),
+		Len:  4,
+		Cap:  4,
+	}
+	buf := *(*[]byte)(unsafe.Pointer(&bh))
+//	hashedKey := siphash.Hash(sipHashKey1, sipHashKey2, buf)
+	hashedKey := XXHash_GoChecksum32(buf)
+
+	// inline HashMap32.getSliceItemForKey()
+	index := hashedKey >> mapData.keyRightShifts
+	sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+	entry := (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer))
+
+	for entry != nil {
+		if entry.keyHash == hashedKey && entry.key == key {
+			// inline ListElement32.Value()
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			value = atomic.LoadPointer(&entry.value)
+			// read again to make sure that the item has not been deleted between the
+			// deleted check and reading of the value
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			return value, true
+		}
+
+		if entry.keyHash > hashedKey {
+			return nil, false
+		}
+
+		entry = (*ListElement32)(atomic.LoadPointer(&entry.nextElement)) // inline ListElement32.Next()
+	}
+	return nil, false
+}
+
+// GetStringKey retrieves an element from the map under given string key.
+func (m *HashMap32) GetStringKey(key string) (value unsafe.Pointer, ok bool) {
+	mapData := (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+	if mapData == nil {
+		return nil, false
+	}
+
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&key))
+	bh := reflect.SliceHeader{
+		Data: sh.Data,
+		Len:  sh.Len,
+		Cap:  sh.Len,
+	}
+	buf := *(*[]byte)(unsafe.Pointer(&bh))
+	// hashedKey := siphash.Hash(sipHashKey1, sipHashKey2, buf)
+	hashedKey := XXHash_GoChecksum32(buf)
+
+	// inline HashMap32.getSliceItemForKey()
+	index := hashedKey >> mapData.keyRightShifts
+	sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+	entry := (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer))
+
+	for entry != nil {
+		if entry.keyHash == hashedKey && entry.key == key {
+			// inline ListElement32.Value()
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			value = atomic.LoadPointer(&entry.value)
+			// read again to make sure that the item has not been deleted between the
+			// deleted check and reading of the value
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			return value, true
+		}
+
+		if entry.keyHash > hashedKey {
+			return nil, false
+		}
+
+		entry = (*ListElement32)(atomic.LoadPointer(&entry.nextElement)) // inline ListElement32.Next()
+	}
+	return nil, false
+}
+
+// GetHashedKey retrieves an element from the map under given hashed key.
+func (m *HashMap32) GetHashedKey(hashedKey uint32) (value unsafe.Pointer, ok bool) {
+	// inline HashMap32.getSliceItemForKey()
+	mapData := (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+	if mapData == nil {
+		return nil, false
+	}
+	index := hashedKey >> mapData.keyRightShifts
+	sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+	entry := (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer))
+
+	for entry != nil {
+		if entry.keyHash == hashedKey {
+			// inline ListElement32.Value()
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			value = atomic.LoadPointer(&entry.value)
+			// read again to make sure that the item has not been deleted between the
+			// deleted check and reading of the value
+			if atomic.LoadUint32(&entry.deleted) == 1 {
+				return nil, false
+			}
+			return value, true
+		}
+
+		if entry.keyHash > hashedKey {
+			return nil, false
+		}
+
+		entry = (*ListElement32)(atomic.LoadPointer(&entry.nextElement)) // inline ListElement32.Next()
+	}
+	return nil, false
+}
+
+// GetOrInsert returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *HashMap32) GetOrInsert(key interface{}, value unsafe.Pointer) (actual unsafe.Pointer, loaded bool) {
+	hashedKey := getKeyHash32(key)
+	var newEntry *ListElement32
+
+	for {
+		// inline HashMap32.getSliceItemForKey()
+		mapData := (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+		if mapData == nil {
+			m.allocate(DefaultSize)
+			mapData = (*hashMapData32)(atomic.LoadPointer(&m.mapDataPtr))
+		}
+		index := hashedKey >> mapData.keyRightShifts
+		sliceDataIndexPointer := (*unsafe.Pointer)(unsafe.Pointer(uintptr(mapData.data) + uintptr(index*intSizeBytes)))
+		sliceItem := (*ListElement32)(atomic.LoadPointer(sliceDataIndexPointer))
+
+		entry := sliceItem
+		for entry != nil {
+			if entry.keyHash == hashedKey && entry.key == key {
+				actual, loaded := entry.GetOrSetValue(value)
+				if loaded {
+					return actual, true
+				}
+
+				list := m.list()
+				atomic.AddUint32(&list.count, 1)
+				return value, false
+			}
+
+			if entry.keyHash > hashedKey {
+				break
+			}
+
+			entry = (*ListElement32)(atomic.LoadPointer(&entry.nextElement)) // inline ListElement32.Next()
+		}
+
+		if newEntry == nil { // allocate only once
+			newEntry = &ListElement32{
+				key:     key,
+				keyHash: hashedKey,
+				value:   value,
+			}
+		}
+
+		if m.insertListElement(newEntry, false) {
+			return value, false
+		}
+	}
+}

--- a/hashmap32_test.go
+++ b/hashmap32_test.go
@@ -1,0 +1,363 @@
+package hashmap
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"unsafe"
+)
+
+// type Animal struct {
+// 	name string
+// }
+
+func TestMapCreation32(t *testing.T) {
+	m := &HashMap32{}
+	if m.Len() != 0 {
+		t.Error("new map should be empty.")
+	}
+}
+
+func TestOverwrite32(t *testing.T) {
+	m := &HashMap32{}
+
+	elephant := "elephant"
+	monkey := "monkey"
+
+	m.Set(1, unsafe.Pointer(&elephant))
+	m.Set(1, unsafe.Pointer(&monkey))
+
+	if m.Len() != 1 {
+		t.Error("map should contain exactly one element.")
+	}
+
+	tmp, ok := m.Get(1) // Retrieve inserted element.
+	if !ok {
+		t.Error("ok should be true for item stored within the map.")
+	}
+
+	item := (*string)(tmp) // Type assertion.
+	if *item != "monkey" {
+		t.Error("wrong item returned.")
+	}
+}
+
+func TestInsert32(t *testing.T) {
+	m := &HashMap32{}
+	c := uint32(16)
+	ok := m.Insert(uint32(128), unsafe.Pointer(&c))
+	if !ok {
+		t.Error("insert did not succeed.")
+	}
+	ok = m.Insert(uint32(128), unsafe.Pointer(&c))
+	if ok {
+		t.Error("insert on existing item did succeed.")
+	}
+	_, ok = m.GetUintKey(128)
+	if !ok {
+		t.Error("ok should be true for item stored within the map.")
+	}
+	if m.Len() != 1 {
+		t.Error("map should contain exactly 1 element.")
+	}
+}
+
+func TestSet32(t *testing.T) {
+	m := New(4)
+	elephant := "elephant"
+	monkey := "monkey"
+
+	m.Set(4, unsafe.Pointer(&elephant))
+	m.Set(3, unsafe.Pointer(&elephant))
+	m.Set(2, unsafe.Pointer(&monkey))
+	m.Set(1, unsafe.Pointer(&monkey))
+
+	if m.Len() != 4 {
+		t.Error("map should contain exactly 4 elements.")
+	}
+}
+
+func TestGet32(t *testing.T) {
+	m := &HashMap32{}
+	elephant := "elephant"
+
+	val, ok := m.Get("animal") // Get a missing element.
+	if ok {
+		t.Error("ok should be false when item is missing from map.")
+	}
+	if val != nil {
+		t.Error("Missing values should return as nil.")
+	}
+
+	m.Set("animal", unsafe.Pointer(&elephant))
+
+	_, ok = m.Get("human") // Get a missing element.
+	if ok {
+		t.Error("ok should be false when item is missing from map.")
+	}
+
+	val, ok = m.Get("animal") // Retrieve inserted element.
+	if !ok {
+		t.Error("ok should be true for item stored within the map.")
+	}
+
+	animal := (*string)(val)
+	if *animal != elephant {
+		t.Error("item was modified.")
+	}
+}
+
+func TestResize32(t *testing.T) {
+	m := New(2)
+	itemCount := 50
+
+	for i := 0; i < itemCount; i++ {
+		m.Set(uint64(i), unsafe.Pointer(&Animal{strconv.Itoa(i)}))
+	}
+
+	if m.Len() != uint64(itemCount) {
+		t.Error("Expected element count did not match.")
+	}
+
+	if m.Fillrate() < 30 {
+		t.Error("Expecting >= 30 percent fillrate.")
+	}
+
+	for i := 0; i < itemCount; i++ {
+		_, ok := m.Get(uint64(i))
+		if !ok {
+			t.Error("Getting inserted item failed.")
+		}
+	}
+}
+
+func TestStringer32(t *testing.T) {
+	m := &HashMap32{}
+	elephant := &Animal{"elephant"}
+	monkey := &Animal{"monkey"}
+
+	s := m.String()
+	if s != "[]" {
+		t.Error("empty map as string does not match.")
+	}
+
+	m.Set(0, unsafe.Pointer(elephant))
+	s = m.String()
+	if s != "[148298089]" {
+		t.Error("1 item map as string does not match:", s)
+	}
+
+	m.Set(1, unsafe.Pointer(monkey))
+	s = m.String()
+	if s != "[148298089,4089149075]" {
+		t.Error("2 item map as string does not match:", s)
+	}
+}
+
+func TestDelete32(t *testing.T) {
+	m := &HashMap32{}
+	m.Del(0)
+
+	elephant := &Animal{"elephant"}
+	monkey := &Animal{"monkey"}
+	m.Set(1, unsafe.Pointer(elephant))
+	m.Set(2, unsafe.Pointer(monkey))
+	m.Del(0)
+	m.Del(3)
+	if m.Len() != 2 {
+		t.Error("map should contain exactly two elements.")
+	}
+
+	m.Del(1)
+	m.Del(1)
+	m.Del(2)
+	if m.Len() != 0 {
+		t.Error("map should be empty.")
+	}
+
+	val, ok := m.Get(1) // Get a missing element.
+	if ok {
+		t.Error("ok should be false when item is missing from map.")
+	}
+	if val != nil {
+		t.Error("Missing values should return as nil.")
+	}
+
+	m.Set(1, unsafe.Pointer(elephant))
+}
+
+func TestIterator32(t *testing.T) {
+	m := &HashMap32{}
+	itemCount := 16
+
+	for i := itemCount; i > 0; i-- {
+		m.Set(uint64(i), unsafe.Pointer(&Animal{strconv.Itoa(i)}))
+	}
+
+	counter := 0
+	for item := range m.Iter() {
+		val := item.Value
+		if val == nil {
+			t.Error("Expecting an object.")
+		}
+		counter++
+	}
+
+	if counter != itemCount {
+		t.Error("Returned item count did not match.")
+	}
+}
+
+func TestHashedKey32(t *testing.T) {
+	m := &HashMap32{}
+	itemCount := 16
+	log := log2_32(uint32(itemCount))
+
+	for i := 0; i < itemCount; i++ {
+		m.SetHashedKey(uint32(i)<<(32-log), unsafe.Pointer(&Animal{strconv.Itoa(i)}))
+	}
+
+	if m.Len() != uint32(itemCount) {
+		t.Error("Expected element count did not match.")
+	}
+
+	for i := 0; i < itemCount; i++ {
+		_, ok := m.GetHashedKey(uint32(i) << (32 - log))
+		if !ok {
+			t.Error("Getting inserted item failed.")
+		}
+	}
+
+	for i := 0; i < itemCount; i++ {
+		m.DelHashedKey(uint32(i) << (32 - log))
+	}
+
+	if m.Len() != uint32(0) {
+		t.Error("Map is not empty.")
+	}
+}
+
+func TestCompareAndSwapHashedKey32(t *testing.T) {
+	m := &HashMap32{}
+	elephant := &Animal{"elephant"}
+	monkey := &Animal{"monkey"}
+
+	m.SetHashedKey(1<<30, unsafe.Pointer(elephant))
+	if m.Len() != 1 {
+		t.Error("map should contain exactly one element.")
+	}
+	if !m.CasHashedKey(1<<30, unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
+		t.Error("Cas should success if expectation met")
+	}
+	if m.CasHashedKey(1<<30, unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
+		t.Error("Cas should fail if expectation didn't meet")
+	}
+	tmp, ok := m.GetHashedKey(1 << 30)
+	if !ok {
+		t.Error("ok should be true for item stored within the map.")
+	}
+	item := (*Animal)(tmp)
+	if item != monkey {
+		t.Error("wrong item returned.")
+	}
+}
+
+func TestCompareAndSwap32(t *testing.T) {
+	m := &HashMap32{}
+	elephant := &Animal{"elephant"}
+	monkey := &Animal{"monkey"}
+
+	m.Set("animal", unsafe.Pointer(elephant))
+	if m.Len() != 1 {
+		t.Error("map should contain exactly one element.")
+	}
+	if !m.Cas("animal", unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
+		t.Error("Cas should success if expectation met")
+	}
+	if m.Cas("animal", unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
+		t.Error("Cas should fail if expectation didn't meet")
+	}
+	tmp, ok := m.Get("animal")
+	if !ok {
+		t.Error("ok should be true for item stored within the map.")
+	}
+	item := (*Animal)(tmp)
+	if item != monkey {
+		t.Error("wrong item returned.")
+	}
+}
+
+// TestAPICounter shows how to use the hashmap to count REST server API calls
+func TestAPICounter32(t *testing.T) {
+	m := &HashMap32{}
+
+	for i := 0; i < 100; i++ {
+		s := fmt.Sprintf("/api%d/", i%4)
+
+		for {
+			val, ok := m.GetStringKey(s)
+			if !ok { // item does not exist yet
+				c := int64(1)
+				if !m.Insert(s, unsafe.Pointer(&c)) {
+					continue // item was inserted concurrently, try to read it again
+				}
+				break
+			}
+
+			c := (*int64)(val)
+			atomic.AddInt64(c, 1)
+			break
+		}
+	}
+
+	s := fmt.Sprintf("/api%d/", 0)
+	val, _ := m.GetStringKey(s)
+	c := (*int64)(val)
+	if *c != 25 {
+		t.Error("wrong API call count.")
+	}
+}
+
+func TestExample32(t *testing.T) {
+	m := &HashMap32{}
+	i := 123
+	m.Set("amount", unsafe.Pointer(&i))
+
+	val, ok := m.Get("amount")
+	if !ok {
+		t.Fail()
+	}
+
+	j := *(*int)(val)
+	if i != j {
+		t.Fail()
+	}
+}
+
+func TestGetOrInsert32(t *testing.T) {
+	m := &HashMap32{}
+
+	var i, j int64
+	actual, loaded := m.GetOrInsert("api1", unsafe.Pointer(&i))
+	if loaded {
+		t.Error("item should have been inserted.")
+	}
+
+	counter := (*int64)(actual)
+	if *counter != 0 {
+		t.Error("item should be 0.")
+	}
+
+	atomic.AddInt64(counter, 1) // increase counter
+
+	actual, loaded = m.GetOrInsert("api1", unsafe.Pointer(&j))
+	if !loaded {
+		t.Error("item should have been loaded.")
+	}
+
+	counter = (*int64)(actual)
+	if *counter != 1 {
+		t.Error("item should be 1.")
+	}
+}

--- a/list.go
+++ b/list.go
@@ -7,8 +7,8 @@ import (
 
 // List is a sorted list.
 type List struct {
-	root  *ListElement
 	count uint64
+	root  *ListElement
 }
 
 // NewList returns an initialized list.

--- a/list32.go
+++ b/list32.go
@@ -1,0 +1,140 @@
+package hashmap
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// List32 is a sorted list.
+type List32 struct {
+	count uint32
+	root  *ListElement32
+}
+
+// NewList32 returns an initialized list.
+func NewList32() *List32 {
+	e := &ListElement32{deleted: 1}
+	e.nextElement = unsafe.Pointer(e) // mark as root by pointing to itself
+
+	return &List32{root: e}
+}
+
+// Len returns the number of elements within the list.
+func (l *List32) Len() uint32 {
+	return atomic.LoadUint32(&l.count)
+}
+
+// First returns the first item of the list.
+func (l *List32) First() *ListElement32 {
+	item := l.root.Next()
+	if item != l.root {
+		return item
+	}
+	return nil
+}
+
+// Add adds an item to the list and returns false if an item for the hash existed.
+func (l *List32) Add(newElement *ListElement32, searchStart *ListElement32) (existed bool, inserted bool) {
+	if searchStart == nil || newElement.keyHash < searchStart.keyHash { // key needs to be inserted on the left? {
+		searchStart = l.root
+	}
+
+	left, found, right := l.search(searchStart, newElement)
+	if found != nil { // existing item found
+		return true, false
+	}
+
+	return false, l.insertAt(newElement, left, right)
+}
+
+// AddOrUpdate adds or updates an item to the list.
+func (l *List32) AddOrUpdate(newElement *ListElement32, searchStart *ListElement32) bool {
+	if searchStart == nil || newElement.keyHash < searchStart.keyHash { // key needs to be inserted on the left? {
+		searchStart = l.root
+	}
+
+	left, found, right := l.search(searchStart, newElement)
+	if found != nil { // existing item found
+		found.SetValue(newElement.value) // update the value
+		if found.SetDeleted(false) {     // try to mark from deleted to not deleted
+			atomic.AddUint32(&l.count, 1)
+		}
+		return true
+	}
+
+	return l.insertAt(newElement, left, right)
+}
+
+// Cas compares and swaps the values and add an item to the list.
+func (l *List32) Cas(newElement *ListElement32, oldValue unsafe.Pointer, searchStart *ListElement32) bool {
+	if searchStart == nil || newElement.keyHash < searchStart.keyHash { // key needs to be inserted on the left? {
+		searchStart = l.root
+	}
+
+	_, found, _ := l.search(searchStart, newElement)
+	if found == nil { // no existing item found
+		return false
+	}
+
+	if found.CasValue(oldValue, newElement.value) {
+		if found.SetDeleted(false) { // try to mark from deleted to not deleted
+			atomic.AddUint32(&l.count, 1)
+		}
+		return true
+	}
+	return false
+}
+
+func (l *List32) search(searchStart *ListElement32, item *ListElement32) (left *ListElement32, found *ListElement32, right *ListElement32) {
+	if searchStart == l.root {
+		found = searchStart.Next()
+		if found == l.root { // no items beside root?
+			return nil, nil, nil
+		}
+		left = searchStart
+	} else {
+		found = searchStart
+	}
+
+	for {
+		if item.keyHash == found.keyHash { // key already exists
+			return nil, found, nil
+		}
+
+		if item.keyHash < found.keyHash { // new item needs to be inserted before the found value
+			return left, nil, found
+		}
+
+		// go to next entry in sorted linked list
+		left = found
+		found = left.Next()
+		if found == nil { // no more items on the right
+			return left, nil, nil
+		}
+	}
+}
+
+func (l *List32) insertAt(newElement *ListElement32, left *ListElement32, right *ListElement32) bool {
+	if left == nil { // insert at root
+		if !atomic.CompareAndSwapPointer(&l.root.nextElement, unsafe.Pointer(l.root), unsafe.Pointer(newElement)) {
+			return false // item was modified concurrently
+		}
+	} else {
+		newElement.nextElement = unsafe.Pointer(right)
+		if !atomic.CompareAndSwapPointer(&left.nextElement, unsafe.Pointer(right), unsafe.Pointer(newElement)) {
+			return false // item was modified concurrently
+		}
+	}
+
+	atomic.AddUint32(&l.count, 1)
+	return true
+}
+
+// Delete marks the list element as deleted.
+func (l *List32) Delete(element *ListElement32) {
+	if !element.SetDeleted(true) {
+		return // element was already deleted
+	}
+
+	atomic.AddUint32(&l.count, ^uint32(0)) // decrease counter
+}

--- a/list32_test.go
+++ b/list32_test.go
@@ -1,0 +1,16 @@
+package hashmap
+
+import "testing"
+
+func TestListNew32(t *testing.T) {
+	l := NewList32()
+	n := l.First()
+	if n != nil {
+		t.Error("First item of list should be nil.")
+	}
+
+	n = l.root.Next()
+	if n != l.root {
+		t.Error("Next element of empty list should be root.")
+	}
+}

--- a/listelement32.go
+++ b/listelement32.go
@@ -5,46 +5,46 @@ import (
 	"unsafe"
 )
 
-// ListElement is an element of the list.
-type ListElement struct {
-	keyHash     uint64
-	deleted     uint64 // for the root and all deleted items this is set to 1
+// ListElement32 is an element of the list.
+type ListElement32 struct {
+	keyHash     uint32
+	deleted     uint32 // for the root and all deleted items this is set to 1
 	nextElement unsafe.Pointer
 	key         interface{}
 	value       unsafe.Pointer
 }
 
 // Value returns the value of the list item.
-func (e *ListElement) Value() (value unsafe.Pointer, ok bool) {
-	if atomic.LoadUint64(&e.deleted) == 1 {
+func (e *ListElement32) Value() (value unsafe.Pointer, ok bool) {
+	if atomic.LoadUint32(&e.deleted) == 1 {
 		return nil, false
 	}
 	value = atomic.LoadPointer(&e.value)
 	// read again to make sure that the item has not been deleted between the
 	// deleted check and reading of the value
-	if atomic.LoadUint64(&e.deleted) == 1 {
+	if atomic.LoadUint32(&e.deleted) == 1 {
 		return nil, false
 	}
 	return value, true
 }
 
 // Deleted returns whether the item was deleted.
-func (e *ListElement) Deleted() bool {
-	return atomic.LoadUint64(&e.deleted) == 1
+func (e *ListElement32) Deleted() bool {
+	return atomic.LoadUint32(&e.deleted) == 1
 }
 
 // Next returns the item on the right.
-func (e *ListElement) Next() *ListElement {
-	return (*ListElement)(atomic.LoadPointer(&e.nextElement))
+func (e *ListElement32) Next() *ListElement32 {
+	return (*ListElement32)(atomic.LoadPointer(&e.nextElement))
 }
 
 // SetDeleted sets the deleted flag of the item.
-func (e *ListElement) SetDeleted(deleted bool) bool {
+func (e *ListElement32) SetDeleted(deleted bool) bool {
 	if !deleted {
-		return atomic.CompareAndSwapUint64(&e.deleted, 1, 0)
+		return atomic.CompareAndSwapUint32(&e.deleted, 1, 0)
 	}
 
-	if !atomic.CompareAndSwapUint64(&e.deleted, 0, 1) {
+	if !atomic.CompareAndSwapUint32(&e.deleted, 0, 1) {
 		return false
 	}
 
@@ -53,25 +53,25 @@ func (e *ListElement) SetDeleted(deleted bool) bool {
 }
 
 // SetValue sets the value of the item.
-func (e *ListElement) SetValue(value unsafe.Pointer) {
+func (e *ListElement32) SetValue(value unsafe.Pointer) {
 	atomic.StorePointer(&e.value, value)
 }
 
 // CasValue compares and swaps the values of the item.
-func (e *ListElement) CasValue(from, to unsafe.Pointer) bool {
+func (e *ListElement32) CasValue(from, to unsafe.Pointer) bool {
 	return atomic.CompareAndSwapPointer(&e.value, from, to)
 }
 
 // GetOrSetValue returns the value of the item.
 // Otherwise, it stores and returns the given value.
 // The loaded result is true if the value was loaded, false if stored.
-func (e *ListElement) GetOrSetValue(value unsafe.Pointer) (actual unsafe.Pointer, loaded bool) {
+func (e *ListElement32) GetOrSetValue(value unsafe.Pointer) (actual unsafe.Pointer, loaded bool) {
 	for {
-		if atomic.LoadUint64(&e.deleted) == 0 { // inline ListElement.Deleted()
+		if atomic.LoadUint32(&e.deleted) == 0 { // inline ListElement32.Deleted()
 			actual = atomic.LoadPointer(&e.value)
 			// read again to make sure that the item has not been deleted between the
 			// deleted check and reading of the value
-			if atomic.LoadUint64(&e.deleted) == 0 {
+			if atomic.LoadUint32(&e.deleted) == 0 {
 				return actual, true
 			}
 		}

--- a/puregoxxhash32.go
+++ b/puregoxxhash32.go
@@ -1,0 +1,316 @@
+// Pure Go implementation from vova616
+// https://github.com/vova616/xxhash
+
+package hashmap
+
+import (
+	"errors"
+	"hash"
+)
+
+const (
+	xxhPRIME32_1 = 2654435761
+	xxhPRIME32_2 = 2246822519
+	xxhPRIME32_3 = 3266489917
+	xxhPRIME32_4 = 668265263
+	xxhPRIME32_5 = 374761393
+)
+
+type xxHash struct {
+	seed, v1, v2, v3, v4 uint32
+	total_len            uint64
+	memory               [16]byte
+	memsize              int
+}
+
+// Pure Go implementation of New32()
+func XXHash_GoNew32() hash.Hash32 {
+	return XXHash_GoNew32Seed(0)
+}
+
+// Pure Go implementation of GoNew32Seed()
+func XXHash_GoNew32Seed(seed uint32) hash.Hash32 {
+	return &xxHash{
+		seed: seed,
+		v1:   seed + xxhPRIME32_1 + xxhPRIME32_2,
+		v2:   seed + xxhPRIME32_2,
+		v3:   seed,
+		v4:   seed - xxhPRIME32_1,
+	}
+}
+
+func (self *xxHash) BlockSize() int {
+	return 1
+}
+
+// Size returns the number of bytes Sum will return.
+func (self *xxHash) Size() int {
+	return 4
+}
+
+func (self *xxHash) feed(in []byte) uint32 {
+	p := 0
+	bEnd := len(in)
+
+	self.total_len += uint64(bEnd)
+
+	// fill in tmp buffer
+	if self.memsize+bEnd < 16 {
+		copy(self.memory[self.memsize:], in)
+		self.memsize += bEnd
+		return 0
+	}
+
+	if self.memsize > 0 {
+		copy(self.memory[self.memsize:], in[:16-self.memsize])
+		var p32 uint32 = uint32(self.memory[0]) |
+			(uint32(self.memory[1]) << 8) |
+			(uint32(self.memory[2]) << 16) |
+			(uint32(self.memory[3]) << 24)
+
+		self.v1 += p32 * xxhPRIME32_2
+		self.v1 = ((self.v1 << 13) | (self.v1 >> (32 - 13))) * xxhPRIME32_1
+
+		p32 = uint32(self.memory[4]) |
+			(uint32(self.memory[5]) << 8) |
+			(uint32(self.memory[6]) << 16) |
+			(uint32(self.memory[7]) << 24)
+
+		self.v2 += p32 * xxhPRIME32_2
+		self.v2 = ((self.v2 << 13) | (self.v2 >> (32 - 13))) * xxhPRIME32_1
+
+		p32 = uint32(self.memory[8]) |
+			(uint32(self.memory[9]) << 8) |
+			(uint32(self.memory[10]) << 16) |
+			(uint32(self.memory[11]) << 24)
+
+		self.v3 += p32 * xxhPRIME32_2
+		self.v3 = ((self.v3 << 13) | (self.v3 >> (32 - 13))) * xxhPRIME32_1
+
+		p32 = uint32(self.memory[12]) |
+			(uint32(self.memory[13]) << 8) |
+			(uint32(self.memory[14]) << 16) |
+			(uint32(self.memory[15]) << 24)
+
+		self.v4 += p32 * xxhPRIME32_2
+		self.v4 = ((self.v4 << 13) | (self.v4 >> (32 - 13))) * xxhPRIME32_1
+
+		s := 16 - self.memsize
+		p += s
+		self.memsize = 0
+	}
+
+	limit := bEnd - 16
+	v1, v2, v3, v4 := self.v1, self.v2, self.v3, self.v4
+
+	for ; p <= limit; p += 16 {
+		var p32 uint32 = uint32(in[p]) |
+			(uint32(in[p+1]) << 8) |
+			(uint32(in[p+2]) << 16) |
+			(uint32(in[p+3]) << 24)
+
+		v1 += p32 * xxhPRIME32_2
+		v1 = ((v1 << 13) | (v1 >> (32 - 13))) * xxhPRIME32_1
+
+		p32 = uint32(in[p+4]) |
+			(uint32(in[p+5]) << 8) |
+			(uint32(in[p+6]) << 16) |
+			(uint32(in[p+7]) << 24)
+
+		v2 += p32 * xxhPRIME32_2
+		v2 = ((v2 << 13) | (v2 >> (32 - 13))) * xxhPRIME32_1
+
+		p32 = uint32(in[p+8]) |
+			(uint32(in[p+9]) << 8) |
+			(uint32(in[p+10]) << 16) |
+			(uint32(in[p+11]) << 24)
+
+		v3 += p32 * xxhPRIME32_2
+		v3 = ((v3 << 13) | (v3 >> (32 - 13))) * xxhPRIME32_1
+
+		p32 = uint32(in[p+12]) |
+			(uint32(in[p+13]) << 8) |
+			(uint32(in[p+14]) << 16) |
+			(uint32(in[p+15]) << 24)
+
+		v4 += p32 * xxhPRIME32_2
+		v4 = ((v4 << 13) | (v4 >> (32 - 13))) * xxhPRIME32_1
+	}
+
+	limit = bEnd - p
+
+	if limit > 0 {
+		copy(self.memory[:], in[p:bEnd])
+		self.memsize = limit
+	}
+
+	self.v1 = v1
+	self.v2 = v2
+	self.v3 = v3
+	self.v4 = v4
+
+	return 0
+}
+
+func (self *xxHash) Sum32() uint32 {
+	p := 0
+	bEnd := self.memsize
+	h32 := uint32(0)
+
+	if self.total_len >= 16 {
+		h32 = ((self.v1 << 1) | (self.v1 >> (32 - 1))) +
+			((self.v2 << 7) | (self.v2 >> (32 - 7))) +
+			((self.v3 << 12) | (self.v3 >> (32 - 12))) +
+			((self.v4 << 18) | (self.v4 >> (32 - 18)))
+	} else {
+		h32 = self.seed + xxhPRIME32_5
+	}
+
+	h32 += uint32(self.total_len)
+
+	for p <= bEnd-4 {
+		var p32 uint32 = uint32(self.memory[p]) |
+			(uint32(self.memory[p+1]) << 8) |
+			(uint32(self.memory[p+2]) << 16) |
+			(uint32(self.memory[p+3]) << 24)
+		h32 += p32 * xxhPRIME32_3
+		h32 = ((h32 << 17) | (h32 >> (32 - 17))) * xxhPRIME32_4
+		p += 4
+	}
+
+	for p < bEnd {
+		h32 += uint32(self.memory[p]) * xxhPRIME32_5
+		h32 = ((h32 << 11) | (h32 >> (32 - 11))) * xxhPRIME32_1
+		p++
+	}
+
+	h32 ^= h32 >> 15
+	h32 *= xxhPRIME32_2
+	h32 ^= h32 >> 13
+	h32 *= xxhPRIME32_3
+	h32 ^= h32 >> 16
+
+	return h32
+}
+
+func (self *xxHash) Sum(in []byte) []byte {
+	h := self.Sum32()
+	in = append(in, byte(h>>24))
+	in = append(in, byte(h>>16))
+	in = append(in, byte(h>>8))
+	in = append(in, byte(h))
+	return in
+}
+
+func (self *xxHash) Reset() {
+	seed := self.seed
+	self.v1 = seed + xxhPRIME32_1 + xxhPRIME32_2
+	self.v2 = seed + xxhPRIME32_2
+	self.v3 = seed
+	self.v4 = seed - xxhPRIME32_1
+	self.total_len = 0
+	self.memsize = 0
+}
+
+// Write adds more data to the running hash.
+// Length of data MUST BE less than 1 Gigabytes.
+func (self *xxHash) Write(data []byte) (nn int, err error) {
+	l := len(data)
+	if l > 1<<30 {
+		return 0, errors.New("Cannot add more than 1 Gigabytes at once.")
+	}
+	self.feed(data)
+	return len(data), nil
+}
+
+// Pure Go implementation of Checksum32()
+func XXHash_GoChecksum32(data []byte) uint32 {
+	return XXHash_GoChecksum32Seed(data, 0)
+}
+
+// Pure Go implementation of Checksum32Seed()
+func XXHash_GoChecksum32Seed(data []byte, seed uint32) uint32 {
+	p := 0
+	bEnd := len(data)
+	h32 := uint32(0)
+
+	if bEnd >= 16 {
+		limit := bEnd - 16
+
+		v1 := seed + xxhPRIME32_1 + xxhPRIME32_2
+		v2 := seed + xxhPRIME32_2
+		v3 := seed + 0
+		v4 := seed - xxhPRIME32_1
+		for {
+			var p32 uint32 = uint32(data[p]) |
+				(uint32(data[p+1]) << 8) |
+				(uint32(data[p+2]) << 16) |
+				(uint32(data[p+3]) << 24)
+
+			v1 += p32 * xxhPRIME32_2
+			v1 = ((v1 << 13) | (v1 >> (32 - 13))) * xxhPRIME32_1
+
+			p32 = uint32(data[p+4]) |
+				(uint32(data[p+5]) << 8) |
+				(uint32(data[p+6]) << 16) |
+				(uint32(data[p+7]) << 24)
+
+			v2 += p32 * xxhPRIME32_2
+			v2 = ((v2 << 13) | (v2 >> (32 - 13))) * xxhPRIME32_1
+
+			p32 = uint32(data[p+8]) |
+				(uint32(data[p+9]) << 8) |
+				(uint32(data[p+10]) << 16) |
+				(uint32(data[p+11]) << 24)
+
+			v3 += p32 * xxhPRIME32_2
+			v3 = ((v3 << 13) | (v3 >> (32 - 13))) * xxhPRIME32_1
+
+			p32 = uint32(data[p+12]) |
+				(uint32(data[p+13]) << 8) |
+				(uint32(data[p+14]) << 16) |
+				(uint32(data[p+15]) << 24)
+
+			v4 += p32 * xxhPRIME32_2
+			v4 = ((v4 << 13) | (v4 >> (32 - 13))) * xxhPRIME32_1
+
+			p += 16
+
+			if p > limit {
+				break
+			}
+		}
+		h32 = ((v1 << 1) | (v1 >> (32 - 1))) +
+			((v2 << 7) | (v2 >> (32 - 7))) +
+			((v3 << 12) | (v3 >> (32 - 12))) +
+			((v4 << 18) | (v4 >> (32 - 18)))
+	} else {
+		h32 = seed + xxhPRIME32_5
+	}
+
+	h32 += uint32(bEnd)
+
+	for p <= bEnd-4 {
+		var p32 uint32 = uint32(data[p]) |
+			(uint32(data[p+1]) << 8) |
+			(uint32(data[p+2]) << 16) |
+			(uint32(data[p+3]) << 24)
+		h32 += p32 * xxhPRIME32_3
+		h32 = ((h32 << 17) | (h32 >> (32 - 17))) * xxhPRIME32_4
+		p += 4
+	}
+
+	for p < bEnd {
+		h32 += uint32(data[p]) * xxhPRIME32_5
+		h32 = ((h32 << 11) | (h32 >> (32 - 11))) * xxhPRIME32_1
+		p++
+	}
+
+	h32 ^= h32 >> 15
+	h32 *= xxhPRIME32_2
+	h32 ^= h32 >> 13
+	h32 *= xxhPRIME32_3
+	h32 ^= h32 >> 16
+
+	return h32
+}

--- a/util.go
+++ b/util.go
@@ -31,6 +31,19 @@ func roundUpPower2(i uint64) uint64 {
 	return i
 }
 
+func roundUpPower2_32(i uint32) uint32 {
+	i--
+	i |= i >> 1
+	i |= i >> 2
+	i |= i >> 4
+	i |= i >> 8
+	i |= i >> 16
+	i++
+	return i
+}
+
+
+
 // log2 computes the binary logarithm of x, rounded up to the next integer.
 func log2(i uint64) uint64 {
 	var n, p uint64
@@ -39,6 +52,16 @@ func log2(i uint64) uint64 {
 	}
 	return n
 }
+
+// log2 computes the binary logarithm of x, rounded up to the next integer.
+func log2_32(i uint32) uint32 {
+	var n, p uint32
+	for p = 1; p < i; p += p {
+		n++
+	}
+	return n
+}
+
 
 // getKeyHash returns a 64 bit hash for the key
 func getKeyHash(key interface{}) uint64 {
@@ -91,4 +114,57 @@ func getKeyHash(key interface{}) uint64 {
 	}
 	buf := *(*[]byte)(unsafe.Pointer(&bh))
 	return siphash.Hash(sipHashKey1, sipHashKey2, buf)
+}
+
+func getKeyHash32(key interface{}) uint32 {
+	var num uint32
+	switch x := key.(type) {
+	case bool:
+		if x {
+			return 1
+		}
+		return 0
+	case string:
+		sh := (*reflect.StringHeader)(unsafe.Pointer(&x))
+		bh := reflect.SliceHeader{
+			Data: sh.Data,
+			Len:  sh.Len,
+			Cap:  sh.Len,
+		}
+		buf := *(*[]byte)(unsafe.Pointer(&bh))
+		return XXHash_GoChecksum32(buf)
+		// return siphash.Hash(sipHashKey1, sipHashKey2, buf)
+	case int:
+		num = uint32(x)
+	case int8:
+		num = uint32(x)
+	case int16:
+		num = uint32(x)
+	case int32:
+		num = uint32(x)
+	case int64:
+		num = uint32(x)
+	case uint:
+		num = uint32(x)
+	case uint8:
+		num = uint32(x)
+	case uint16:
+		num = uint32(x)
+	case uint32:
+		num = uint32(x)
+	case uint64:
+		num = uint32(x)
+	case uintptr:
+		num = uint32(x)
+	default:
+		panic(fmt.Errorf("unsupported key type %T", key))
+	}
+
+	bh := reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(&num)),
+		Len:  4,
+		Cap:  4,
+	}
+	buf := *(*[]byte)(unsafe.Pointer(&bh))
+	return XXHash_GoChecksum32(buf)
 }


### PR DESCRIPTION
I just swapped the order of field in List. This partially fixes problems on 32-bit ARM. It passes all tests, but fails on a benchmark. Probably due to a AddInt64 call.

```
root@wigwagrelay:~/go-workspace/src/github.com/cornelk/hashmap# go test
PASS
ok  	github.com/cornelk/hashmap	0.023s
root@wigwagrelay:~/go-workspace/src/github.com/cornelk/hashmap# go test -bench=.
BenchmarkReadHashMapUint-2                	    2000	    846979 ns/op
BenchmarkReadHashMapWithWritesUint-2      	--- FAIL: BenchmarkReadHashMapWithWritesUint-2
BenchmarkReadHashMapString-2              	     500	   2481451 ns/op
BenchmarkReadHashMapInterface-2           	    1000	   2514878 ns/op
BenchmarkReadHashMapHashedKey-2           	    2000	    744152 ns/op
BenchmarkReadGoMapUintUnsafe-2            	    5000	    231738 ns/op
BenchmarkReadGoMapUintMutex-2             	    5000	    414895 ns/op
BenchmarkReadGoMapWithWritesUintMutex-2   	    1000	   2226309 ns/op
BenchmarkReadGoSyncMapUint-2              	    1000	   1633804 ns/op
BenchmarkReadGoSyncMapWithWritesUint-2    	    1000	   2079039 ns/op
BenchmarkReadGoMapStringUnsafe-2          	    2000	   1549876 ns/op
BenchmarkReadGoMapStringMutex-2           	    1000	   1802993 ns/op
BenchmarkWriteHashMapUint-2               	     300	   4837673 ns/op
BenchmarkWriteHashMapHashedKey-2          	     300	   3929762 ns/op
BenchmarkWriteGoMapMutexUint-2            	    1000	   1134647 ns/op
BenchmarkWriteGoSyncMapUint-2             	     300	   5139583 ns/op
FAIL
exit status 1
FAIL	github.com/cornelk/hashmap	34.995s
root@wigwagrelay:~/go-workspace/src/github.com/cornelk/hashmap# 
```