### PR TITLE
Use uintptr instead of uint64 to support 32 bit systems with same cod…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A Golang thread-safe HashMap optimized for fastest lock-free read access on 64 bit systems.
+A Golang thread-safe HashMap optimized for fastest lock-free read access.
 
 ## Usage
 

--- a/hashmap_get.go
+++ b/hashmap_get.go
@@ -26,13 +26,13 @@ func (m *HashMap) Get(key interface{}) (value unsafe.Pointer, ok bool) {
 	for entry != nil {
 		if entry.keyHash == hashedKey && entry.key == key {
 			// inline ListElement.Value()
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			value = atomic.LoadPointer(&entry.value)
 			// read again to make sure that the item has not been deleted between the
 			// deleted check and reading of the value
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			return value, true
@@ -48,7 +48,7 @@ func (m *HashMap) Get(key interface{}) (value unsafe.Pointer, ok bool) {
 }
 
 // GetUintKey retrieves an element from the map under given integer key.
-func (m *HashMap) GetUintKey(key uint64) (value unsafe.Pointer, ok bool) {
+func (m *HashMap) GetUintKey(key uintptr) (value unsafe.Pointer, ok bool) {
 	mapData := (*hashMapData)(atomic.LoadPointer(&m.mapDataPtr))
 	if mapData == nil {
 		return nil, false
@@ -60,7 +60,7 @@ func (m *HashMap) GetUintKey(key uint64) (value unsafe.Pointer, ok bool) {
 		Cap:  8,
 	}
 	buf := *(*[]byte)(unsafe.Pointer(&bh))
-	hashedKey := siphash.Hash(sipHashKey1, sipHashKey2, buf)
+	hashedKey := uintptr(siphash.Hash(sipHashKey1, sipHashKey2, buf))
 
 	// inline HashMap.getSliceItemForKey()
 	index := hashedKey >> mapData.keyRightShifts
@@ -70,13 +70,13 @@ func (m *HashMap) GetUintKey(key uint64) (value unsafe.Pointer, ok bool) {
 	for entry != nil {
 		if entry.keyHash == hashedKey && entry.key == key {
 			// inline ListElement.Value()
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			value = atomic.LoadPointer(&entry.value)
 			// read again to make sure that the item has not been deleted between the
 			// deleted check and reading of the value
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			return value, true
@@ -105,7 +105,7 @@ func (m *HashMap) GetStringKey(key string) (value unsafe.Pointer, ok bool) {
 		Cap:  sh.Len,
 	}
 	buf := *(*[]byte)(unsafe.Pointer(&bh))
-	hashedKey := siphash.Hash(sipHashKey1, sipHashKey2, buf)
+	hashedKey := uintptr(siphash.Hash(sipHashKey1, sipHashKey2, buf))
 
 	// inline HashMap.getSliceItemForKey()
 	index := hashedKey >> mapData.keyRightShifts
@@ -115,13 +115,13 @@ func (m *HashMap) GetStringKey(key string) (value unsafe.Pointer, ok bool) {
 	for entry != nil {
 		if entry.keyHash == hashedKey && entry.key == key {
 			// inline ListElement.Value()
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			value = atomic.LoadPointer(&entry.value)
 			// read again to make sure that the item has not been deleted between the
 			// deleted check and reading of the value
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			return value, true
@@ -137,7 +137,7 @@ func (m *HashMap) GetStringKey(key string) (value unsafe.Pointer, ok bool) {
 }
 
 // GetHashedKey retrieves an element from the map under given hashed key.
-func (m *HashMap) GetHashedKey(hashedKey uint64) (value unsafe.Pointer, ok bool) {
+func (m *HashMap) GetHashedKey(hashedKey uintptr) (value unsafe.Pointer, ok bool) {
 	// inline HashMap.getSliceItemForKey()
 	mapData := (*hashMapData)(atomic.LoadPointer(&m.mapDataPtr))
 	if mapData == nil {
@@ -150,13 +150,13 @@ func (m *HashMap) GetHashedKey(hashedKey uint64) (value unsafe.Pointer, ok bool)
 	for entry != nil {
 		if entry.keyHash == hashedKey {
 			// inline ListElement.Value()
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			value = atomic.LoadPointer(&entry.value)
 			// read again to make sure that the item has not been deleted between the
 			// deleted check and reading of the value
-			if atomic.LoadUint64(&entry.deleted) == 1 {
+			if atomic.LoadUintptr(&entry.deleted) == 1 {
 				return nil, false
 			}
 			return value, true
@@ -198,7 +198,7 @@ func (m *HashMap) GetOrInsert(key interface{}, value unsafe.Pointer) (actual uns
 				}
 
 				list := m.list()
-				atomic.AddUint64(&list.count, 1)
+				atomic.AddUintptr(&list.count, 1)
 				return value, false
 			}
 

--- a/hashmap_get.go
+++ b/hashmap_get.go
@@ -56,8 +56,8 @@ func (m *HashMap) GetUintKey(key uintptr) (value unsafe.Pointer, ok bool) {
 
 	bh := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(&key)),
-		Len:  8,
-		Cap:  8,
+		Len:  intSizeBytes,
+		Cap:  intSizeBytes,
 	}
 	buf := *(*[]byte)(unsafe.Pointer(&bh))
 	hashedKey := uintptr(siphash.Hash(sipHashKey1, sipHashKey2, buf))

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -144,13 +144,15 @@ func TestStringer(t *testing.T) {
 
 	m.Set(0, unsafe.Pointer(elephant))
 	s = m.String()
-	if s != "[9257401834698437112]" {
+	hashedKey0 := getKeyHash(0)
+	if s != fmt.Sprintf("[%v]", hashedKey0) {
 		t.Error("1 item map as string does not match:", s)
 	}
 
 	m.Set(1, unsafe.Pointer(monkey))
 	s = m.String()
-	if s != "[1754102016959854353,9257401834698437112]" {
+	hashedKey1 := getKeyHash(1)
+	if s != fmt.Sprintf("[%v,%v]", hashedKey1, hashedKey0) {
 		t.Error("2 item map as string does not match:", s)
 	}
 }

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -243,17 +243,17 @@ func TestCompareAndSwapHashedKey(t *testing.T) {
 	elephant := &Animal{"elephant"}
 	monkey := &Animal{"monkey"}
 
-	m.SetHashedKey(1<<62, unsafe.Pointer(elephant))
+	m.SetHashedKey(1<<(strconv.IntSize-2), unsafe.Pointer(elephant))
 	if m.Len() != 1 {
 		t.Error("map should contain exactly one element.")
 	}
-	if !m.CasHashedKey(1<<62, unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
+	if !m.CasHashedKey(1<<(strconv.IntSize-2), unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
 		t.Error("Cas should success if expectation met")
 	}
-	if m.CasHashedKey(1<<62, unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
+	if m.CasHashedKey(1<<(strconv.IntSize-2), unsafe.Pointer(elephant), unsafe.Pointer(monkey)) {
 		t.Error("Cas should fail if expectation didn't meet")
 	}
-	tmp, ok := m.GetHashedKey(1 << 62)
+	tmp, ok := m.GetHashedKey(1 << (strconv.IntSize - 2))
 	if !ok {
 		t.Error("ok should be true for item stored within the map.")
 	}

--- a/list.go
+++ b/list.go
@@ -7,8 +7,8 @@ import (
 
 // List is a sorted list.
 type List struct {
+	count uintptr
 	root  *ListElement
-	count uint64
 }
 
 // NewList returns an initialized list.
@@ -20,8 +20,8 @@ func NewList() *List {
 }
 
 // Len returns the number of elements within the list.
-func (l *List) Len() uint64 {
-	return atomic.LoadUint64(&l.count)
+func (l *List) Len() int {
+	return int(atomic.LoadUintptr(&l.count))
 }
 
 // First returns the first item of the list.
@@ -57,7 +57,7 @@ func (l *List) AddOrUpdate(newElement *ListElement, searchStart *ListElement) bo
 	if found != nil { // existing item found
 		found.SetValue(newElement.value) // update the value
 		if found.SetDeleted(false) {     // try to mark from deleted to not deleted
-			atomic.AddUint64(&l.count, 1)
+			atomic.AddUintptr(&l.count, 1)
 		}
 		return true
 	}
@@ -78,7 +78,7 @@ func (l *List) Cas(newElement *ListElement, oldValue unsafe.Pointer, searchStart
 
 	if found.CasValue(oldValue, newElement.value) {
 		if found.SetDeleted(false) { // try to mark from deleted to not deleted
-			atomic.AddUint64(&l.count, 1)
+			atomic.AddUintptr(&l.count, 1)
 		}
 		return true
 	}
@@ -126,7 +126,7 @@ func (l *List) insertAt(newElement *ListElement, left *ListElement, right *ListE
 		}
 	}
 
-	atomic.AddUint64(&l.count, 1)
+	atomic.AddUintptr(&l.count, 1)
 	return true
 }
 
@@ -136,5 +136,5 @@ func (l *List) Delete(element *ListElement) {
 		return // element was already deleted
 	}
 
-	atomic.AddUint64(&l.count, ^uint64(0)) // decrease counter
+	atomic.AddUintptr(&l.count, ^uintptr(0)) // decrease counter
 }

--- a/util.go
+++ b/util.go
@@ -19,7 +19,7 @@ const (
 )
 
 // roundUpPower2 rounds a number to the next power of 2.
-func roundUpPower2(i uint64) uint64 {
+func roundUpPower2(i uintptr) uintptr {
 	i--
 	i |= i >> 1
 	i |= i >> 2
@@ -32,17 +32,17 @@ func roundUpPower2(i uint64) uint64 {
 }
 
 // log2 computes the binary logarithm of x, rounded up to the next integer.
-func log2(i uint64) uint64 {
-	var n, p uint64
+func log2(i uintptr) uintptr {
+	var n, p uintptr
 	for p = 1; p < i; p += p {
 		n++
 	}
 	return n
 }
 
-// getKeyHash returns a 64 bit hash for the key
-func getKeyHash(key interface{}) uint64 {
-	var num uint64
+// getKeyHash returns a hash for the key
+func getKeyHash(key interface{}) uintptr {
+	var num uintptr
 	switch x := key.(type) {
 	case bool:
 		if x {
@@ -57,29 +57,29 @@ func getKeyHash(key interface{}) uint64 {
 			Cap:  sh.Len,
 		}
 		buf := *(*[]byte)(unsafe.Pointer(&bh))
-		return siphash.Hash(sipHashKey1, sipHashKey2, buf)
+		return uintptr(siphash.Hash(sipHashKey1, sipHashKey2, buf))
 	case int:
-		num = uint64(x)
+		num = uintptr(x)
 	case int8:
-		num = uint64(x)
+		num = uintptr(x)
 	case int16:
-		num = uint64(x)
+		num = uintptr(x)
 	case int32:
-		num = uint64(x)
+		num = uintptr(x)
 	case int64:
-		num = uint64(x)
+		num = uintptr(x)
 	case uint:
-		num = uint64(x)
+		num = uintptr(x)
 	case uint8:
-		num = uint64(x)
+		num = uintptr(x)
 	case uint16:
-		num = uint64(x)
+		num = uintptr(x)
 	case uint32:
-		num = uint64(x)
+		num = uintptr(x)
 	case uint64:
-		num = uint64(x)
+		num = uintptr(x)
 	case uintptr:
-		num = uint64(x)
+		num = x
 	default:
 		panic(fmt.Errorf("unsupported key type %T", key))
 	}
@@ -90,5 +90,5 @@ func getKeyHash(key interface{}) uint64 {
 		Cap:  8,
 	}
 	buf := *(*[]byte)(unsafe.Pointer(&bh))
-	return siphash.Hash(sipHashKey1, sipHashKey2, buf)
+	return uintptr(siphash.Hash(sipHashKey1, sipHashKey2, buf))
 }

--- a/util.go
+++ b/util.go
@@ -86,8 +86,8 @@ func getKeyHash(key interface{}) uintptr {
 
 	bh := reflect.SliceHeader{
 		Data: uintptr(unsafe.Pointer(&num)),
-		Len:  8,
-		Cap:  8,
+		Len:  intSizeBytes,
+		Cap:  intSizeBytes,
 	}
 	buf := *(*[]byte)(unsafe.Pointer(&bh))
 	return uintptr(siphash.Hash(sipHashKey1, sipHashKey2, buf))

--- a/util_test.go
+++ b/util_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestLog2(t *testing.T) {
-	var fixtures = map[uint64]uint64{
+	var fixtures = map[uintptr]uintptr{
 		0: 0,
 		1: 0,
 		2: 1,


### PR DESCRIPTION
This should allow to use the hashmap on 32 bit systems without need of copying the codebase to files that use 32 bit instead of 64 bit variables.

@edhemphill  please test and review
