### PR TITLE
Run travis tests on go 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 script:
   - go test -coverprofile=coverage.txt -covermode=atomic


### PR DESCRIPTION
Hey I was just browsing this repo again and noticed you didn't yet run the tests on go 1.10 on Travis.

Additionally it would be interesting to run the benchmarks again with that version and see if there are any noticeable changes compared to go 1.9.

Best regards
Friedrich