### PR TITLE
vgo support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cornelk/hashmap
+
+require github.com/dchest/siphash v1.1.0


### PR DESCRIPTION
`go.mod` adds dependency management compatible with [vgo](https://github.com/golang/go/wiki/vgo).