### PR TITLE
fix hash conflict when set value

### DIFF
--- a/list.go
+++ b/list.go
@@ -86,7 +86,7 @@ func (l *List) search(searchStart *ListElement, item *ListElement) (left *ListEl
 	}
 
 	for {
-		if item.keyHash == found.keyHash { // key already exists
+		if item.keyHash == found.keyHash && item.key == found.key { // key already exists
 			return nil, found, nil
 		}
 


### PR DESCRIPTION
Change-Id: I01e01a4f819fd2b8d9d6d46c5f25462a60b4cf19
There is a potential problem that if I have two keys with same getHashKey value.
I modified getHashKey function and try to let it return same value all the time.
```
func TestHash(t *testing.T) {
	hash := hashmap.New(8)
	hash.Set("a" ,1)
	hash.Set("a" ,3)
	hash.Set("b" ,2)

	t.Log(hash.Get("a"))
	t.Log(hash.Get("b"))

}
```
The result of this test case is: a 2, nil false.