### PR TITLE
Add full support for `[]byte` key type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 script:
   - go test -race -coverprofile=coverage.txt -covermode=atomic

--- a/hashmap.go
+++ b/hashmap.go
@@ -123,9 +123,19 @@ func (m *HashMap) Del(key interface{}) {
 	h := getKeyHash(key)
 
 	var element *ListElement
+ElementLoop:
 	for _, element = m.indexElement(h); element != nil; element = element.Next() {
-		if element.keyHash == h && element.key == key {
-			break
+		if element.keyHash == h {
+			switch key.(type) {
+			case []byte:
+				if bytes.Compare(element.key.([]byte), key.([]byte)) == 0 {
+					break ElementLoop
+				}
+			default:
+				if element.key == key {
+					break ElementLoop
+				}
+			}
 		}
 
 		if element.keyHash > h {

--- a/hashmap_get.go
+++ b/hashmap_get.go
@@ -142,9 +142,18 @@ func (m *HashMap) GetOrInsert(key interface{}, value interface{}) (actual interf
 		}
 
 		for element != nil {
-			if element.keyHash == h && element.key == key {
-				actual = element.Value()
-				return actual, true
+			if element.keyHash == h {
+				switch key.(type) {
+				case []byte:
+					if bytes.Compare(element.key.([]byte), key.([]byte)) == 0 {
+						return element.Value(), true
+					}
+				default:
+					if element.key == key {
+						actual = element.Value()
+						return actual, true
+					}
+				}
 			}
 
 			if element.keyHash > h {

--- a/hashmap_get.go
+++ b/hashmap_get.go
@@ -1,6 +1,7 @@
 package hashmap
 
 import (
+	"bytes"
 	"reflect"
 	"unsafe"
 
@@ -19,8 +20,17 @@ func (m *HashMap) Get(key interface{}) (value interface{}, ok bool) {
 
 	// inline HashMap.searchItem()
 	for element != nil {
-		if element.keyHash == h && element.key == key {
-			return element.Value(), true
+		if element.keyHash == h {
+			switch key.(type) {
+			case []byte:
+				if bytes.Compare(element.key.([]byte), key.([]byte)) == 0 {
+					return element.Value(), true
+				}
+			default:
+				if element.key == key {
+					return element.Value(), true
+				}
+			}
 		}
 
 		if element.keyHash > h {

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -174,6 +174,37 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestGetUintKey(t *testing.T) {
+	m := &HashMap{}
+	elephant := "elephant"
+	key0 := uintptr(0)
+	key1 := uintptr(1)
+
+	val, ok := m.GetUintKey(key0) // Get a missing element.
+	if ok {
+		t.Error("ok should be false when item is missing from map.")
+	}
+	if val != nil {
+		t.Error("Missing values should return as nil.")
+	}
+
+	m.Set(key0, elephant)
+
+	_, ok = m.GetUintKey(key1) // Get a missing element.
+	if ok {
+		t.Error("ok should be false when item is missing from map.")
+	}
+
+	value, ok := m.GetUintKey(key0) // Retrieve inserted element.
+	if !ok {
+		t.Error("ok should be true for item stored within the map.")
+	}
+
+	if value != elephant {
+		t.Error("item was modified.")
+	}
+}
+
 func TestGrow(t *testing.T) {
 	m := &HashMap{}
 	m.Grow(uintptr(63))

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -191,39 +191,51 @@ func TestStringer(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	m := &HashMap{}
-	m.Del(0)
-
-	elephant := &Animal{"elephant"}
-	monkey := &Animal{"monkey"}
-	m.Set(1, elephant)
-	m.Set(2, monkey)
-	m.Del(0)
-	m.Del(3)
-	if m.Len() != 2 {
-		t.Error("map should contain exactly two elements.")
+	tests := []struct {
+		name string
+		key  func(int) interface{}
+	}{
+		{name: "int", key: func(i int) interface{} { return i }},
+		{name: "string", key: func(i int) interface{} { return strconv.Itoa(i) }},
+		{name: "[]byte", key: func(i int) interface{} { return []byte(strconv.Itoa(i) + "bytes") }},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &HashMap{}
+			m.Del(tt.key(0))
 
-	m.Del(1)
-	m.Del(1)
-	m.Del(2)
-	if m.Len() != 0 {
-		t.Error("map should be empty.")
-	}
+			elephant := &Animal{"elephant"}
+			monkey := &Animal{"monkey"}
+			m.Set(tt.key(1), elephant)
+			m.Set(tt.key(2), monkey)
+			m.Del(tt.key(0))
+			m.Del(tt.key(3))
+			if m.Len() != 2 {
+				t.Error("map should contain exactly two elements.")
+			}
 
-	for item := range m.Iter() {
-		t.Errorf("map should be empty but got %v in the iterator.", item)
-	}
+			m.Del(tt.key(1))
+			m.Del(tt.key(1))
+			m.Del(tt.key(2))
+			if m.Len() != 0 {
+				t.Error("map should be empty.")
+			}
 
-	val, ok := m.Get(1) // Get a missing element.
-	if ok {
-		t.Error("ok should be false when item is missing from map.")
-	}
-	if val != nil {
-		t.Error("Missing values should return as nil.")
-	}
+			for item := range m.Iter() {
+				t.Errorf("map should be empty but got %v in the iterator.", item)
+			}
 
-	m.Set(1, elephant)
+			val, ok := m.Get(tt.key(1)) // Get a missing element.
+			if ok {
+				t.Error("ok should be false when item is missing from map.")
+			}
+			if val != nil {
+				t.Error("Missing values should return as nil.")
+			}
+
+			m.Set(tt.key(1), elephant)
+		})
+	}
 }
 
 func TestIterator(t *testing.T) {

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -384,6 +384,22 @@ func TestExample(t *testing.T) {
 	}
 }
 
+func TestByteSlice(t *testing.T) {
+	m := &HashMap{}
+	k := []byte(`Well this is a fine mess`)
+	i := 123
+	m.Set(k, i)
+
+	j, ok := m.Get(k)
+	if !ok {
+		t.Fail()
+	}
+
+	if i != j {
+		t.Fail()
+	}
+}
+
 func TestHashMap_parallel(t *testing.T) {
 	max := 10
 	dur := 2 * time.Second

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -176,32 +176,33 @@ func TestGet(t *testing.T) {
 
 func TestGetUintKey(t *testing.T) {
 	m := &HashMap{}
-	elephant := "elephant"
-	key0 := uintptr(0)
-	key1 := uintptr(1)
-
-	val, ok := m.GetUintKey(key0) // Get a missing element.
+	_, ok := m.GetUintKey(0)
 	if ok {
-		t.Error("ok should be false when item is missing from map.")
+		t.Error("empty map should not return an item.")
 	}
-	if val != nil {
-		t.Error("Missing values should return as nil.")
+	c := uintptr(16)
+	ok = m.Insert(uintptr(0), c)
+	if !ok {
+		t.Error("insert did not succeed.")
 	}
-
-	m.Set(key0, elephant)
-
-	_, ok = m.GetUintKey(key1) // Get a missing element.
+	ok = m.Insert(uintptr(128), c)
+	if !ok {
+		t.Error("insert did not succeed.")
+	}
+	ok = m.Insert(uintptr(128), c)
 	if ok {
-		t.Error("ok should be false when item is missing from map.")
+		t.Error("insert on existing item did succeed.")
 	}
-
-	value, ok := m.GetUintKey(key0) // Retrieve inserted element.
+	_, ok = m.GetUintKey(128)
 	if !ok {
 		t.Error("ok should be true for item stored within the map.")
 	}
-
-	if value != elephant {
-		t.Error("item was modified.")
+	_, ok = m.GetUintKey(127)
+	if ok {
+		t.Error("item for key should not exist.")
+	}
+	if m.Len() != 2 {
+		t.Errorf("map should contain exactly 2 elements but has %v items.", m.Len())
 	}
 }
 


### PR DESCRIPTION
On functions that validate that a matching hash really belongs to the provided key, a comparison between `element.key` and the provided `key` will panic if the type of the key (or for that matter, the type of `element.key`) is `[]byte`.

This enhances the comparisons to use a standard `==` comparison of keys for non-byte slice keys, and use `bytes.Compare()` for `[]byte` keys.

I had to enhance many of the tests to include multiple key types in each test case and make sure that `[]byte` keys are thoroughly tested. As a result of that, I added an additional test case for `GetUintKey()` to make sure the test coverage didn't decrease.