### PR TITLE
update xsync version and add write benchmark

### DIFF
--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/alphadose/haxmap"
 	"github.com/cornelk/hashmap"
-	"github.com/puzpuzpuz/xsync"
+	"github.com/puzpuzpuz/xsync/v2"
 	"github.com/zhangyunhao116/skipmap"
 )
 
@@ -214,6 +214,32 @@ func BenchmarkReadXsyncMapUint(b *testing.B) {
 				j, _ := m.Load(i)
 				if j != i {
 					b.Fail()
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkReadXsyncMapWithWritesUint(b *testing.B) {
+	m := setupXsync(b)
+	var writer uintptr
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		// use 1 thread as writer
+		if atomic.CompareAndSwapUintptr(&writer, 0, 1) {
+			for pb.Next() {
+				for i := uint64(0); i < benchmarkItemCount; i++ {
+					m.Store(i, i)
+				}
+			}
+		} else {
+			for pb.Next() {
+				for i := uint64(0); i < benchmarkItemCount; i++ {
+					j, _ := m.Load(i)
+					if j != i {
+						b.Fail()
+					}
 				}
 			}
 		}

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -7,7 +7,7 @@ replace github.com/cornelk/hashmap => ../
 require (
 	github.com/alphadose/haxmap v1.1.0
 	github.com/cornelk/hashmap v1.0.8
-	github.com/puzpuzpuz/xsync v1.5.2
+	github.com/puzpuzpuz/xsync/v2 v2.3.1
 	github.com/zhangyunhao116/skipmap v0.10.1
 )
 

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -1,14 +1,8 @@
-github.com/alphadose/haxmap v0.3.2-0.20220906124448-c6ee4c0e1f5d h1:GbecHhDTEKKpycM5JxYyplhaDV8RQNDWfy1vr9B8ETw=
-github.com/alphadose/haxmap v0.3.2-0.20220906124448-c6ee4c0e1f5d/go.mod h1:Fu37Wlmj7cR++vSLgRTu3fGy8wpjHGmMypM2aclkc1A=
 github.com/alphadose/haxmap v1.1.0 h1:M7Dxdr+civMQkWCgDpoktNpLofDBz7XzdS3rF3Y6r4U=
 github.com/alphadose/haxmap v1.1.0/go.mod h1:Pq2IXbl9/ytYHfrIAd7rIVtZQ2ezdIhZfvdqOizDeWY=
-github.com/puzpuzpuz/xsync v1.5.2 h1:yRAP4wqSOZG+/4pxJ08fPTwrfL0IzE/LKQ/cw509qGY=
-github.com/puzpuzpuz/xsync v1.5.2/go.mod h1:K98BYhX3k1dQ2M63t1YNVDanbwUPmBCAhNmVrrxfiGg=
-github.com/zhangyunhao116/fastrand v0.2.1 h1:H5FygwAWuYF7IqJKrdWBbphgHffRC07okNQjT2qbGB4=
-github.com/zhangyunhao116/fastrand v0.2.1/go.mod h1:0v5KgHho0VE6HU192HnY15de/oDS8UrbBChIFjIhBtc=
+github.com/puzpuzpuz/xsync/v2 v2.3.1 h1:oAm/nI4ZC+FqOM7t2fnA7DaQVsuj4fO2KcTcNTS1Q9Y=
+github.com/puzpuzpuz/xsync/v2 v2.3.1/go.mod h1:gD2H2krq/w52MfPLE+Uy64TzJDVY7lP2znR9qmR35kU=
 github.com/zhangyunhao116/fastrand v0.3.0 h1:7bwe124xcckPulX6fxtr2lFdO2KQqaefdtbk+mqO/Ig=
 github.com/zhangyunhao116/fastrand v0.3.0/go.mod h1:0v5KgHho0VE6HU192HnY15de/oDS8UrbBChIFjIhBtc=
-github.com/zhangyunhao116/skipmap v0.9.1 h1:w9ei+cnzgl6TodHGDk+VXurlZfIonyB8X5mpjArAzd8=
-github.com/zhangyunhao116/skipmap v0.9.1/go.mod h1:lr61q2jYDJMUFuSivumPxAJxygEkwXfSfIocXu6Qqxg=
 github.com/zhangyunhao116/skipmap v0.10.1 h1:CMH4yGZQESBM1kUNozQqQ+Ra2pKqwF3HxaTADOaIfPs=
 github.com/zhangyunhao116/skipmap v0.10.1/go.mod h1:CClnLPHl3DI+hHgrcy0OZ/QJ45AWgA3ObVcQyJop12c=


### PR DESCRIPTION
Updates xsync version used in benchmarks to v2.3.1 and adds a benchmark for read-write scenario.

Results on my machine are the following:
```bash
$ go test -benchmem -bench .
goos: linux
goarch: amd64
pkg: github.com/cornelk/hashmap/benchmarks
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkReadHashMapUint-8                	  897908	      1324 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadHashMapWithWritesUint-8      	  705546	      1611 ns/op	     212 B/op	      26 allocs/op
BenchmarkReadHashMapString-8              	  404989	      2992 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadHaxMapUint-8                 	  799784	      1479 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadHaxMapWithWritesUint-8       	  655464	      1765 ns/op	     209 B/op	      26 allocs/op
BenchmarkReadXsyncMapUint-8               	 1000000	      1014 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadXsyncMapWithWritesUint-8     	  911084	      1225 ns/op	     230 B/op	      14 allocs/op
BenchmarkReadSkipMapUint-8                	  193857	      5779 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadGoMapUintUnsafe-8            	  867796	      1422 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadGoMapUintMutex-8             	   41556	     28843 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadGoMapWithWritesUintMutex-8   	   14640	     81796 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadGoSyncMapUint-8              	  264541	      4988 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadGoSyncMapWithWritesUint-8    	  221808	      5406 ns/op	    1061 B/op	      94 allocs/op
BenchmarkReadGoMapStringUnsafe-8          	  555124	      2184 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadGoMapStringMutex-8           	   44901	     26670 ns/op	       0 B/op	       0 allocs/op
BenchmarkWriteHashMapUint-8               	   47112	     25137 ns/op	    8193 B/op	    1024 allocs/op
BenchmarkWriteGoMapMutexUint-8            	   45098	     25838 ns/op	       1 B/op	       0 allocs/op
BenchmarkWriteGoSyncMapUint-8             	   15714	     79569 ns/op	   28681 B/op	    2560 allocs/op
PASS
ok  	github.com/cornelk/hashmap/benchmarks	24.325s
```